### PR TITLE
fixed bug in functions for active users metrics

### DIFF
--- a/wikichron/dash/apps/classic/metrics/stats.py
+++ b/wikichron/dash/apps/classic/metrics/stats.py
@@ -120,7 +120,7 @@ def edits_user_talk(data, index):
 
 def users_active_more_than_x_editions(data, index, x):
     monthly_edits = data.groupby([pd.Grouper(key='timestamp', freq='MS'), 'contributor_name']).size()
-    monthly_edits_filtered = monthly_edits[monthly_edits > x].to_frame(name='pages_edited').reset_index()
+    monthly_edits_filtered = monthly_edits[monthly_edits >= x].to_frame(name='pages_edited').reset_index()
     series = monthly_edits_filtered.groupby(pd.Grouper(key='timestamp', freq='MS')).size()
     if index is not None:
         series = series.reindex(index, fill_value=0)
@@ -187,17 +187,17 @@ def users_anonymous_active(data, index):
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 4 editions.
 def users_active_more_than_4_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 4)
+    return users_active_more_than_x_editions(data, index, 5)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 24 editions.
 def users_active_more_than_24_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 24)
+    return users_active_more_than_x_editions(data, index, 25)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 99 editions.
 def users_active_more_than_99_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 99)
+    return users_active_more_than_x_editions(data, index, 100)
 
 
 ########################################################################


### PR DESCRIPTION
This pull request is intended to fix a bug in the calculations for the active users metrics. The helper function users_active_more_than_x_editions filtered the users according to whether they have made or not a number of editions strictly higher than a parameter X. The function users_active called this helper function with X = 1, thus, the returned number was the number of users who had edited more than once. Now, the helper function users_active_more_than_x_editions has been changed in order to get the number of users who have edited a number of times >= x.