### PR TITLE
Bug active users

### DIFF
--- a/wikichron/dash/apps/classic/metrics/stats.py
+++ b/wikichron/dash/apps/classic/metrics/stats.py
@@ -119,7 +119,7 @@ def edits_user_talk(data, index):
 
 
 def users_active_more_than_x_editions(data, index, x):
-    monthly_edits = data.groupby([pd.Grouper(key='timestamp', freq='MS'), 'contributor_name']).size()
+    monthly_edits = data.groupby([pd.Grouper(key='timestamp', freq='MS'), 'contributor_id']).size()
     monthly_edits_filtered = monthly_edits[monthly_edits >= x].to_frame(name='pages_edited').reset_index()
     series = monthly_edits_filtered.groupby(pd.Grouper(key='timestamp', freq='MS')).size()
     if index is not None:

--- a/wikichron/dash/apps/classic/metrics/stats.py
+++ b/wikichron/dash/apps/classic/metrics/stats.py
@@ -120,7 +120,7 @@ def edits_user_talk(data, index):
 
 def users_active_more_than_x_editions(data, index, x):
     monthly_edits = data.groupby([pd.Grouper(key='timestamp', freq='MS'), 'contributor_id']).size()
-    monthly_edits_filtered = monthly_edits[monthly_edits >= x].to_frame(name='pages_edited').reset_index()
+    monthly_edits_filtered = monthly_edits[monthly_edits > x].to_frame(name='pages_edited').reset_index()
     series = monthly_edits_filtered.groupby(pd.Grouper(key='timestamp', freq='MS')).size()
     if index is not None:
         series = series.reindex(index, fill_value=0)
@@ -169,7 +169,7 @@ def users_registered_accum(data, index):
 
 
 def users_active(data, index):
-    return users_active_more_than_x_editions(data, index, 1)
+    return users_active_more_than_x_editions(data, index, 0)
 
 
 # this metric is the same as the users_active, but getting rid of anonymous users
@@ -187,17 +187,17 @@ def users_anonymous_active(data, index):
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 4 editions.
 def users_active_more_than_4_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 5)
+    return users_active_more_than_x_editions(data, index, 4)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 24 editions.
 def users_active_more_than_24_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 25)
+    return users_active_more_than_x_editions(data, index, 24)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 99 editions.
 def users_active_more_than_99_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 100)
+    return users_active_more_than_x_editions(data, index, 99)
 
 
 ########################################################################

--- a/wikichron/dash/apps/classic/metrics/stats.py
+++ b/wikichron/dash/apps/classic/metrics/stats.py
@@ -120,7 +120,7 @@ def edits_user_talk(data, index):
 
 def users_active_more_than_x_editions(data, index, x):
     monthly_edits = data.groupby([pd.Grouper(key='timestamp', freq='MS'), 'contributor_name']).size()
-    monthly_edits_filtered = monthly_edits[monthly_edits > x].to_frame(name='pages_edited').reset_index()
+    monthly_edits_filtered = monthly_edits[monthly_edits >= x].to_frame(name='pages_edited').reset_index()
     series = monthly_edits_filtered.groupby(pd.Grouper(key='timestamp', freq='MS')).size()
     if index is not None:
         series = series.reindex(index, fill_value=0)
@@ -187,17 +187,17 @@ def users_anonymous_active(data, index):
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 4 editions.
 def users_active_more_than_4_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 4)
+    return users_active_more_than_x_editions(data, index, 5)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 24 editions.
 def users_active_more_than_24_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 24)
+    return users_active_more_than_x_editions(data, index, 25)
 
 
 # this metric gets, per month, those users who have contributed to the wiki in more than 99 editions.
 def users_active_more_than_99_editions(data, index):
-    return users_active_more_than_x_editions(data, index, 99)
+    return users_active_more_than_x_editions(data, index, 100)
 
 
 ########################################################################


### PR DESCRIPTION
This pull request is intended to solve the following issue:  in the helper function users_active_more_than_x_editions, we were using a group by contributor_name, which could be duplicated for some users (for example, anonymous users). Now, the contributor_id is used.