### PR TITLE
Added 'ready' to networks and use it to better init sliderHandlerLabels.js

### DIFF
--- a/wikichron/dash/apps/networks/main.py
+++ b/wikichron/dash/apps/networks/main.py
@@ -59,6 +59,24 @@ def update_query_by_time(query_string, up_val, low_val):
 def bind_callbacks(app):
 
     @app.callback(
+        Output('ready', 'children'),
+        [Input('dates-slider', 'value'),
+        Input('initial-selection', 'children'),
+        Input('dates-index', 'children'),
+        Input('dates-index-end', 'children')]
+    )
+    def ready(*args):
+        #~ print (args)
+        if not all(args):
+            #~ print('not ready!')
+            return None
+        else:
+            if debug:
+                print('Ready to plot network!')
+            return 'ready'
+
+
+    @app.callback(
         Output('network-ready', 'value'),
         [Input('dates-slider', 'value')],
         [State('initial-selection', 'children'),

--- a/wikichron/dash/apps/networks/main_view.py
+++ b/wikichron/dash/apps/networks/main_view.py
@@ -504,6 +504,7 @@ def generate_main_content(wikis_arg, network_type_arg, query_string):
 
                 # Signal data
                 html.Div(id='network-ready', style={'display': 'none'}),
+                html.Div(id='ready', style={'display': 'none'}),
                 html.Div(id='old-state-node', style={'display': 'none'}),
                 html.Div(id='highlight-node', style={'display': 'none'}),
                 html.Div(id='dates-index', className='time-index', children=time_index_beginning, style={'display': 'none'}),

--- a/wikichron/js/common/dash/sliderHandlerLabels.js
+++ b/wikichron/js/common/dash/sliderHandlerLabels.js
@@ -41,10 +41,10 @@ function get_date(val) {
 
 function update_labels(mutation) {
 
-    //~ if (mutation['attributeName'] === "aria-valuenow") {
+    if (mutation['attributeName'] === "aria-valuenow") {
         const val = parseInt(mutation.target.getAttribute("aria-valuenow"), 10);
         mutation.target.children[0].children[0].innerHTML = get_date(val);
-    //~ }
+    }
 }
 
 
@@ -61,9 +61,6 @@ for (i = 0; i < handlerClasses.length; i++){
 
     // now, add event when value change
     observer = new MutationObserver( function(mutations){
-        console.log(`Slider handle: ${mutations} mutated!!!`);
-
-
         mutations.forEach(update_labels);
     });
     observer.observe(handlers[i], { attributes: true});
@@ -72,18 +69,19 @@ for (i = 0; i < handlerClasses.length; i++){
 
 /* Setting time index observer */
 const timeIndexDiv = document.querySelector(".time-index");
-const TimeAxisSwitchObserver = new MutationObserver(function(mutations, observer) {
+const ready = document.querySelector("#ready");
+const initHandlerLabelsObserver = new MutationObserver(function(mutations, observer) {
 
     mutations.forEach(function(){
 
         for (i = 0; i < handlerClasses.length; i++){
-            console.log(`TimeAxis: handler: ${handlers[i]} mutated!!!`);
             init_labels(handlers[i], `handler-label${i}`);
         }
     });
 });
 
-TimeAxisSwitchObserver.observe(timeIndexDiv, {subtree: true, characterData: true})
+initHandlerLabelsObserver.observe(ready, {childList: true}); // initialization
+initHandlerLabelsObserver.observe(timeIndexDiv, {subtree: true, characterData: true}); // when timeIndex changes
 
 
 


### PR DESCRIPTION
I've added a empty div 'ready' to be able to know when the dash app was loaded for first time, and thus init the slider handler labels in a more efficient way. Can you please, @FRYoussef, double check that the 'ready' div initialization is done in the right way?